### PR TITLE
使贴子在当前活动的编辑器标签页的行/列中打开

### DIFF
--- a/src/commands/topicItemClick.ts
+++ b/src/commands/topicItemClick.ts
@@ -32,7 +32,7 @@ function _createPanel(id: string, label: string): vscode.WebviewPanel {
   const panel = vscode.window.createWebviewPanel(
     id,
     _getTitle(label),
-    vscode.ViewColumn.One,
+    vscode.ViewColumn.Active,
     {
       enableScripts: true,
       retainContextWhenHidden: true,


### PR DESCRIPTION
这个是我摸鱼时用的 VSCode 布局：

![白板图片](https://user-images.githubusercontent.com/16899918/147313701-5ba35097-7aa4-4679-9566-c015640dbe24.jpg)

现在扩展的行为是：
当 3 是活动窗口时，点击侧栏里帖子列表中的帖子，这时帖子的 webview 始终会在最左上角的窗口 1 中打开，不隐蔽。

修改后的行为：
当 3 是活动窗口时，点击侧栏里帖子列表中的帖子，这时帖子的 webview 会在当前活动窗口 3 中打开，更隐蔽。